### PR TITLE
Increase the number of secondary workers and run time

### DIFF
--- a/scripts/vds_combiner/hgdp_1kg/main.py
+++ b/scripts/vds_combiner/hgdp_1kg/main.py
@@ -16,7 +16,8 @@ batch = hb.Batch(name='hgdp-1kg-vds', backend=service_backend)
 dataproc.hail_dataproc_job(
     batch,
     'generate_combined_hgdp_1kg_vds.py',
-    max_age='6h',
+    max_age='12h',
+    num_secondary_workers=20,
     init=['gs://cpg-common-main/hail_dataproc/install_common.sh'],
     job_name='hgdp_1kg_vds',
 )


### PR DESCRIPTION
Unfortunately I overlooked adding extra workers to this script (I was too focused on the marker selection script). I've increased the amount of workers, as well as the time to run, after the `generate_combined_hgdp_1kg_vds.py` script failed with an out of memory error. See log [here](https://batch.hail.populationgenomics.org.au/batches/421964/jobs/2) for reference.