### PR TITLE
Add in version number to allow for files which already exist

### DIFF
--- a/scripts/marker_selection_all_datasets/marker_selection_hgdp_1kg_all_datasets.py
+++ b/scripts/marker_selection_all_datasets/marker_selection_hgdp_1kg_all_datasets.py
@@ -33,7 +33,7 @@ def main(vds_path, output_version):
     hgdp_onekg.variant_data = hgdp_onekg.variant_data.select_entries(hgdp_onekg.variant_data.LGT, hgdp_onekg.variant_data.LA)
     input_dataset.variant_data = input_dataset.variant_data.select_entries(input_dataset.variant_data.LGT, input_dataset.variant_data.LA)
     # save datasets to tmp bucket
-    tmp_hgdp_onekg_output = dataset_path(f'vds/combiner/filtered_entries_hgdp_1kg.vds', 'tmp')
+    tmp_hgdp_onekg_output = dataset_path(f'vds/combiner/filtered_entries_hgdp_1kg_{output_version}.vds', 'tmp')
     tmp_input_dataset_output = dataset_path(f'vds/combiner/filtered_entries_{output_version}.vds', 'tmp')
     hgdp_onekg.write(tmp_hgdp_onekg_output)
     input_dataset.write(tmp_input_dataset_output)


### PR DESCRIPTION
If a file already exists on `main`, the script will fail. This fix allows for added versioning, which creates unique files. 
See https://batch.hail.populationgenomics.org.au/batches/423001/jobs/2